### PR TITLE
Fix error message that could potentially be null

### DIFF
--- a/modules/core/src/main/scala/io/toolsplus/atlassian/jwt/JwtParser.scala
+++ b/modules/core/src/main/scala/io/toolsplus/atlassian/jwt/JwtParser.scala
@@ -19,7 +19,8 @@ object JwtParser {
     Try(JWSObject.parse(input)) match {
       case Success(jwsObject) => Right(jwsObject)
       case Failure(exception) =>
-        Left(ParsingFailure(exception.getMessage, exception))
+        val message = Option(exception.getMessage).getOrElse("Parsing JWS object failed")
+        Left(ParsingFailure(message, exception))
     }
   }
 


### PR DESCRIPTION
- Wrap message in option and provide alternative message if it's null